### PR TITLE
Fix test problems in docstring PR

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -18,6 +18,8 @@ def test_singledocstringtool():
     collection = client.get_or_create_collection(
         name=constants.DEFAULT_COLLECTION_NAME
     )
+    _clear_collection(collection)
+
     example_ids = [
         'apples.py',
         'apples.py::foo (function)',
@@ -181,6 +183,7 @@ def test_lintfiletool():
     collection = client.get_or_create_collection(
         name=constants.DEFAULT_COLLECTION_NAME
     )
+    _clear_collection(collection)
 
     example_ids_metadatas = [
         (str(idx), dict(filepath=f'src/{name}.py'))
@@ -211,3 +214,10 @@ def test_lintfiletool():
         '1': 'src/bananas.py',
         '2': 'src/oranges.py'
     }
+
+
+def _clear_collection(collection: chromadb.Collection) -> None:
+    """clear a collection"""
+    uids = collection.get()['ids']
+    if uids:
+        collection.delete(ids=uids)


### PR DESCRIPTION
It appears that the chromadb ephermeralclient allows the collection to persist across instances (!) so with cam's `test_singledocstringtool()` the unit tests now fail when run with pytest. This is a quick PR to fix this issue by deleting anything that may be in the collection after `get_or_create_collection`. There are probably other ways to solve this like deleting the collection rather than the contents but this seems to work.