### PR TITLE
macOS-specific Installation Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,21 @@ If the "tools" of `groundcrew` are like workers helping you with your code-relat
 
 ## Installation
 
-Run the following commands to install `groundcrew` in a dedicated Python (Anaconda) environment.
+Run the following commands to install `groundcrew` in a dedicated Python (Anaconda) environment:
 
 ```shell
 git clone https://github.com/prolego-team/groundcrew.git
 conda env create -f groundcrew/env.yaml
+```
+
+If you're on macOS, run this command:
+
+```shell
+conda init zsh
+```
+Then, regardless of platofrm, run the following commmands:
+
+```shell
 conda activate groundcrew
 pip install -e groundcrew
 cd groundcrew

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you're on macOS, run this command:
 
 ```shell
 conda init zsh
-source ~/.zshr
+source ~/.zshrc
 ```
 Then, regardless of platofrm, run the following commmands:
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ If you're on macOS, run this command:
 
 ```shell
 conda init zsh
+source ~/.zshr
 ```
 Then, regardless of platofrm, run the following commmands:
 


### PR DESCRIPTION
Hi folks, first time user of ground crew own a Mac that didn't have conda etc installed. I found myself in a loop of conda activate -> conda init -> conda activate until I realised I needed to add zsh to the conda init and then source the zshrc to pick up the necessary init. 